### PR TITLE
Removed unnecessary parent::__call in LagoonClient.

### DIFF
--- a/src/LagoonClient.php
+++ b/src/LagoonClient.php
@@ -84,6 +84,5 @@ class LagoonClient implements LagoonClientInterface {
       }
       return $this->operations[$method];
     }
-    return parent::__call($method, $arguments);
   }
 }


### PR DESCRIPTION
This  triggers an error:
```
Deprecated: Cannot use \"parent\" when current class scope has no parent in /private/var/lib/awx/govcms-migrate/tools/lagoon-php-sdk/vendor/steveworley/lagoon-php-sdk/src/LagoonClient.php on line 87
```